### PR TITLE
updated get_match, put_match, fixes match caching issue

### DIFF
--- a/stores/django_cache.py
+++ b/stores/django_cache.py
@@ -5,7 +5,7 @@ import copy
 from datapipelines import DataSource, DataSink, PipelineContext, Query, validate_query, NotFoundError
 from backends.cache_backend import DjangoCacheBackend
 
-from cassiopeia.data import Platform, Region, Queue
+from cassiopeia.data import Platform, Region, Queue, Continent
 from cassiopeia.dto.common import DtoObject
 from cassiopeia.dto.champion import ChampionRotationDto
 from cassiopeia.dto.championmastery import ChampionMasteryDto, ChampionMasteryListDto
@@ -266,23 +266,23 @@ class DjangoCache(DataSource, DataSink):
     # Match
 
     _validate_get_match_query = Query. \
-        has("id").as_(int).also. \
-        has("platform").as_(Platform)
+        has("id").as_(str).also. \
+        has("continent").as_(Continent)
 
     @get.register(MatchDto)
     @validate_query(_validate_get_match_query, convert_region_to_platform)
     def get_match(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> MatchDto:
         key = "{clsname}.{platform}.{id}".format(clsname=MatchDto.__name__,
-                                                 platform=query["platform"].value,
+                                                 platform=query["continent"].value,
                                                  id=query["id"])
         return MatchDto(self._get(key))
 
     @put.register(MatchDto)
     def put_match(self, item: MatchDto, context: PipelineContext = None) -> None:
-        platform = Region(item["region"]).platform.value
+        platform = Continent(item["continent"]).value
         key = "{clsname}.{platform}.{id}".format(clsname=MatchDto.__name__,
                                                  platform=platform,
-                                                 id=item["gameId"])
+                                                 id=item["matchId"])
         self._put(key, item)
 
     # Match list


### PR DESCRIPTION
fixes #7 
When trying to cache a match using the example DjangoCache in the Cassiopeia pipeline a ValueError is raised because
`invalid literal for int() with base 10: 'NA1_4105627717'`
changing the given id into an integer i.e 4105627717 did not work either.

I looked at what the query was in the traceback and found that it looked like the following
`query {'continent': <Continent.americas: 'AMERICAS'>, 'id': 'NA1_4105627717'}`
so the first thing I did was change was the type validation and what the query needed to contain

I then changed def get_match and def put_match, I replaced the platform with the continent in both functions and replaced gameId with matchId in put_match

the new key format would look like `MatchDto.AMERICAS.NA1_4105627717`